### PR TITLE
feat: add API for posting leaderboard scores

### DIFF
--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Constants.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Constants.cs
@@ -46,6 +46,11 @@ namespace Monaverse.Api
                 public static string GetTokenAnimation(BigInteger chainId, string contract, string tokenId) 
                     => $"public/tokens/{chainId}/{contract}/{tokenId}/animation";
             }
+            
+            public static class Leaderboard
+            { 
+                public const string PostScore = "public/leaderboards/sdk/score";
+            }
         }
     }
 }

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/IMonaApiClient.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/IMonaApiClient.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Monaverse.Api.Modules.Auth;
+using Monaverse.Api.Modules.Leaderboard;
 using Monaverse.Api.Modules.Token;
 using Monaverse.Api.Modules.User;
 using Monaverse.Api.MonaHttpClient.Request;
@@ -14,6 +15,7 @@ namespace Monaverse.Api
         IUserApiModule User { get; }
         ITokenApiModule Token { get; }
         IMonaApiSession Session { get; }
+        ILeaderboardApiModule Leaderboard { get; }
         bool IsAuthorized();
         
         string GetUrlWithPath(string path);

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard.meta
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b08cdbfb64f410ba8a4d112bc7bc6c8
+timeCreated: 1726593707

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/ILeaderboardApiModule.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/ILeaderboardApiModule.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Monaverse.Api.Modules.Common;
+
+namespace Monaverse.Api.Modules.Leaderboard
+{
+    public interface ILeaderboardApiModule
+    {
+        Task<ApiResult> PostScore(PostScoreRequest request);
+    }
+}

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/ILeaderboardApiModule.cs.meta
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/ILeaderboardApiModule.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 24a01909631f4323b4513cabfb0219ac
+timeCreated: 1726594303

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/LeaderboardApiModule.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/LeaderboardApiModule.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Monaverse.Api.Modules.Common;
+using Monaverse.Api.MonaHttpClient.Extensions;
+using Monaverse.Api.MonaHttpClient.Request;
+
+namespace Monaverse.Api.Modules.Leaderboard
+{
+    public sealed class LeaderboardApiModule : ILeaderboardApiModule
+    {
+        private readonly IMonaApiClient _monaApiClient;
+
+        public LeaderboardApiModule(IMonaApiClient monaApiClient)
+        {
+            _monaApiClient = monaApiClient;
+        }
+
+        public async Task<ApiResult> PostScore(PostScoreRequest request)
+        {
+            var monaHttpRequest = new MonaHttpRequest(
+                url: _monaApiClient.GetUrlWithPath(Constants.Endpoints.Leaderboard.PostScore),
+                method: RequestMethod.Post)
+                .WithBody(request);
+            
+            var response = await _monaApiClient.SendAuthenticated(monaHttpRequest);
+            return response.ToApiResult();
+        }
+    }
+}

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/LeaderboardApiModule.cs.meta
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/LeaderboardApiModule.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9c78af07032a4cb58718247407c57893
+timeCreated: 1726593744

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests.meta
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 65eb05e4b4784461adeab53ceade53ac
+timeCreated: 1726593855

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests/PostScoreRequest.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests/PostScoreRequest.cs
@@ -1,0 +1,10 @@
+namespace Monaverse.Api.Modules.Leaderboard
+{
+    public record PostScoreRequest
+    {
+        public float Score { get; set; }
+        public string Topic { get; set; }
+        public long Timestamp { get; set; }
+        public string Signature { get; set; }
+    }
+}

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests/PostScoreRequest.cs.meta
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/Modules/Leaderboard/Requests/PostScoreRequest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cf254ec436224c28af6b34faeb989bde
+timeCreated: 1726593878

--- a/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/MonaApiClientImpl.cs
+++ b/Assets/Monaverse/Core/Plugins/Mona/com.monaverse.api/Rutime/MonaApiClientImpl.cs
@@ -5,6 +5,7 @@ using Monaverse.Api.Extensions;
 using Monaverse.Api.Logging;
 using Monaverse.Api.Modules.Auth;
 using Monaverse.Api.Modules.Auth.Requests;
+using Monaverse.Api.Modules.Leaderboard;
 using Monaverse.Api.Modules.Token;
 using Monaverse.Api.Modules.User;
 using Monaverse.Api.MonaHttpClient;
@@ -24,6 +25,7 @@ namespace Monaverse.Api
         public IAuthApiModule Auth { get; private set; }
         public IUserApiModule User { get; private set; }
         public ITokenApiModule Token { get; private set; }
+        public ILeaderboardApiModule Leaderboard { get; private set; }
         
         public IMonaApiSession Session { get; }
 
@@ -40,6 +42,7 @@ namespace Monaverse.Api
             Auth = new AuthApiModule(this, monaApiLogger);
             User = new UserApiModule(this);
             Token = new TokenApiModule(this);
+            Leaderboard = new LeaderboardApiModule(this);
         }
 
         public bool IsAuthorized()

--- a/Assets/Monaverse/Core/Scripts/Utils/SecurityExtensions.cs
+++ b/Assets/Monaverse/Core/Scripts/Utils/SecurityExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Monaverse.Core.Scripts.Utils
+{
+    public static class SecurityExtensions
+    {
+        public static string GenerateHmac(this string message, string key)
+        {
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key));
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+            return Convert.ToBase64String(hash);
+        }
+    }
+}

--- a/Assets/Monaverse/Core/Scripts/Utils/SecurityExtensions.cs.meta
+++ b/Assets/Monaverse/Core/Scripts/Utils/SecurityExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: da3c146a6ee543cd900ab5f2ae3501b7
+timeCreated: 1726594855

--- a/Assets/Monaverse/Examples/MonaverseModal/Scenes/mona-modal-example.unity
+++ b/Assets/Monaverse/Examples/MonaverseModal/Scenes/mona-modal-example.unity
@@ -913,6 +913,52 @@ MonoBehaviour:
   _itemsPool:
   - {fileID: 9161117842829642491}
   _selectedItem: {fileID: 1010368422}
+--- !u!1 &1281417292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1281417294}
+  - component: {fileID: 1281417293}
+  m_Layer: 0
+  m_Name: MonaverseLeaderboardExample
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1281417293
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281417292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da99e7dd1a1041eeb45dd8f0b7c65784, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _score: 25
+  _topic: 
+--- !u!4 &1281417294
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281417292}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -474.25, y: -267.25, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2124564574}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1283445396
 GameObject:
   m_ObjectHideFlags: 0
@@ -1828,6 +1874,7 @@ RectTransform:
   - {fileID: 559718273}
   - {fileID: 1010368421}
   - {fileID: 1129006316}
+  - {fileID: 1281417294}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Monaverse/Examples/MonaverseModal/Scripts/MonaLeaderboardExample.cs
+++ b/Assets/Monaverse/Examples/MonaverseModal/Scripts/MonaLeaderboardExample.cs
@@ -1,0 +1,30 @@
+using Monaverse.Core;
+using UnityEngine;
+
+namespace Monaverse.Examples
+{
+    public class MonaLeaderboardExample : MonoBehaviour
+    {
+        [SerializeField] private float _score;
+        [SerializeField] private string _topic;
+        
+        /// For security reasons, do not use serialized fields to store secrets
+        private string _sdkSecret = "YOUR_SDK_SECRET_HERE";
+
+        private void Start()
+        {
+            //You can set the SDK secret once on startup
+            MonaverseManager.Instance.SDK.SetSecret(_sdkSecret);
+        }
+        
+        [ContextMenu("Post Score")]
+        public async void PostScore()
+        {
+            var result = await MonaverseManager.Instance.SDK
+                .PostScore(score: _score,
+                    topic: _topic,
+                    sdkSecret: _sdkSecret); //Optionally, pass in the SDK secret if not set on startup
+            Debug.Log(result);
+        }
+    }
+}

--- a/Assets/Monaverse/Examples/MonaverseModal/Scripts/MonaLeaderboardExample.cs.meta
+++ b/Assets/Monaverse/Examples/MonaverseModal/Scripts/MonaLeaderboardExample.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: da99e7dd1a1041eeb45dd8f0b7c65784
+timeCreated: 1726667092


### PR DESCRIPTION
- Implemented functionality to securely submit user scores to the leaderboard from the Unity client.
- Added HMAC authentication using the `SDK Secret` for score submissions.
- Standardised score formatting to ensure consistent hashing with the server.
- Included timestamp in submissions to prevent replay attacks.
- Updated SDK methods and provided usage examples for developers