### PR TITLE
fix: exception thrown when user has no linked wallets

### DIFF
--- a/Assets/Monaverse/Modal/Scripts/UI/Views/UserTokensView.cs
+++ b/Assets/Monaverse/Modal/Scripts/UI/Views/UserTokensView.cs
@@ -289,6 +289,13 @@ namespace Monaverse.Modal.UI.Views
                     return null;
                 }
 
+                //Check if selected wallet exists in dropdown
+                if (_walletsDropdown.options.Count <= _walletsDropdown.value)
+                {
+                    parentModal.Header.Snackbar.Show(MonaSnackbar.Type.Error, "No wallets linked");
+                    return null;
+                }
+                
                 var wallet = _walletsDropdown.options[_walletsDropdown.value].text;
 
                 if (string.IsNullOrEmpty(wallet))


### PR DESCRIPTION
Fixes exception thrown in the modal UI when opening the tokens view with no wallets linked to your account.

```
ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
System.Collections.Generic.List`1[T].get_Item (System.Int32 index) (at <fd2d3e9b010a4ba4b3fdc0456cd6b40b>:0)
Monaverse.Modal.UI.Views.UserTokensView.GetUserTokens () (at Assets/Monaverse/Modal/Scripts/UI/Views/UserTokensView.cs:292)
```