### PR TITLE
fix: add UI support for token pagination and multiple wallets

### DIFF
--- a/Assets/Monaverse/Core/Scripts/MonaWalletSDK.cs
+++ b/Assets/Monaverse/Core/Scripts/MonaWalletSDK.cs
@@ -217,7 +217,7 @@ namespace Monaverse.Core
         /// <param name="chainId"> The id of the chain to get the tokens for</param>
         /// <param name="address"> The wallet address to get the tokens for</param>
         /// <returns> The user's tokens for the specified chain and wallet address </returns>
-        public async Task<ApiResult<GetUserTokensResponse>> GetUserTokens(int chainId, string address)
+        public async Task<ApiResult<GetUserTokensResponse>> GetUserTokens(int chainId, string address, string continuation = null)
         {
             try
             {
@@ -226,7 +226,8 @@ namespace Monaverse.Core
 
                 var result = await ApiClient.User
                     .GetUserTokens(chainId: chainId,
-                        address: address);
+                        address: address,
+                        continuation: continuation);
 
                 //TODO: Do some caching here
 

--- a/Assets/Monaverse/Examples/MonaverseModal/Scenes/mona-modal-example.unity
+++ b/Assets/Monaverse/Examples/MonaverseModal/Scenes/mona-modal-example.unity
@@ -942,8 +942,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: da99e7dd1a1041eeb45dd8f0b7c65784, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _limit: 20
+  _offset: 0
+  _featured: 0
+  _topScoresTopic: 
+  _sortingOrder: 0
+  _period: 3
+  _includeAllUserScores: 0
   _score: 25
-  _topic: 
+  _postScoreTopic: 
 --- !u!4 &1281417294
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Monaverse/Modal/Prefabs/MonaverseModal.prefab
+++ b/Assets/Monaverse/Modal/Prefabs/MonaverseModal.prefab
@@ -6227,7 +6227,7 @@ MonoBehaviour:
   _logoutButton: {fileID: 7103486301149417629}
   _marketplaceButton: {fileID: 8810611155634337571}
   _cardPrefab: {fileID: 6712057078394093190, guid: 292be3cab959a4362973798816f3ed03, type: 3}
-  _loadThreshold: 0.5
+  _loadThreshold: 0.2
 --- !u!1 &4773609382004046662
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Monaverse/Modal/Scripts/UI/Views/UserTokensView.cs
+++ b/Assets/Monaverse/Modal/Scripts/UI/Views/UserTokensView.cs
@@ -40,7 +40,7 @@ namespace Monaverse.Modal.UI.Views
         private MonaListItem _cardPrefab;
 
         [SerializeField, Range(0.01f, 0.9f)]
-        private float _loadThreshold = 0.5f;
+        private float _loadThreshold = 0.2f;
 
         private readonly Dictionary<string, MonaRemoteSprite> _sprites = new();
 
@@ -157,7 +157,7 @@ namespace Monaverse.Modal.UI.Views
             //Filter using the CollectibleFilter
             MonaverseModal.TriggerTokensLoaded(tokens.GetFilteredTokens());
 
-            _tokensCache = tokens;
+            _tokensCache.AddRange(tokens);
             _usedCardsCount += getUserTokensResponse.Tokens.Count;
 
             _isPageLoading = false;
@@ -173,8 +173,6 @@ namespace Monaverse.Modal.UI.Views
 
         private async Task RefreshView(IReadOnlyList<TokenDto> tokens)
         {
-            
-
             if (tokens.Count > _cardsPool.Count - _usedCardsCount)
                 await IncreaseCardsPoolSize(tokens.Count + _usedCardsCount);
 
@@ -306,7 +304,8 @@ namespace Monaverse.Modal.UI.Views
 
                 var result = await MonaverseManager.Instance.SDK
                     .GetUserTokens(chainId: chainId,
-                        address: wallet);
+                        address: wallet,
+                        continuation: _continuationToken);
 
                 if (!result.IsSuccess)
                 {


### PR DESCRIPTION
This fixes an issue with wallets containing more tokens than the UI page limit (20) would not load more tokens over the limit.

- Scroll to bottom to load next page
- Load happens additively 
- Loaded tokens are kept in UI unless wallet is changed
- Going into the details page won't reset the list view